### PR TITLE
Modify hubot-scripts template

### DIFF
--- a/confd/templates/hubot-scripts.json.tmpl
+++ b/confd/templates/hubot-scripts.json.tmpl
@@ -1,6 +1,6 @@
 [
-{{range gets "/hubot/hubot-scripts/*"}}
-  "{{base .Key}}",
+{{range ls "/hubot/hubot-scripts"}}
+  "{{.}}",
 {{end}}
   "hello"
 ]


### PR DESCRIPTION
Modify hubot-scripts template so that it does not error out if you do… not have any custom scripts, using `ls` instead of `gets`. Better since we only have keys anyway and were only using the key.

It does work and does not need the base:

Here is an example with one key:

```
[

  "eight-ball",

  "hello"
]
```
